### PR TITLE
Add testing workflow on Github Actions

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer:v2
           coverage: none
 
       - name: Install Dependencies

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,8 @@
 name: Run Tests
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -7,12 +7,16 @@ on:
 jobs:
   test:
     name: Run Tests
+
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         php: ['8.0', '8.1', '8.2', '8.3']
         dependency-version: [prefer-lowest, prefer-stable]
+
     name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,19 +12,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -21,7 +21,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: intl, imagick
           coverage: none
 
       - name: Install Dependencies

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,8 +6,6 @@ on:
 
 jobs:
   test:
-    name: Run Tests
-
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,6 +8,11 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.0', '8.1', '8.2', '8.3']
+        dependency-version: [prefer-lowest, prefer-stable]
+    name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -15,12 +20,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ matrix.php }}
           extensions: intl, imagick
           coverage: none
 
       - name: Install Dependencies
-        run: composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
+        run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
       - name: Execute Tests
         run: composer test:unit

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -23,4 +23,4 @@ jobs:
         run: composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
 
       - name: Execute Tests
-        run: ./vendor/bin/phpunit
+        run: composer test:unit

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^2.6",
-        "laravel/pint": "^1.13",
+        "laravel/pint": "^1.0",
         "rector/rector": "^0.18.7",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-strict-rules": "^1.5"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "guzzlehttp/guzzle": "^7.8"
     },
     "require-dev": {
-        "pestphp/pest": "^2.0",
+        "pestphp/pest": "^1.0|^2.0",
         "laravel/pint": "^1.0",
         "rector/rector": "^0.18.7",
         "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "guzzlehttp/guzzle": "^7.8"
     },
     "require-dev": {
-        "pestphp/pest": "^1.0|^2.0",
+        "pestphp/pest": "^1.23.6|^2.0",
         "laravel/pint": "^1.0",
         "rector/rector": "^0.18.7",
         "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "guzzlehttp/guzzle": "^7.8"
     },
     "require-dev": {
-        "pestphp/pest": "^2.6",
+        "pestphp/pest": "^2.0",
         "laravel/pint": "^1.0",
         "rector/rector": "^0.18.7",
         "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "guzzlehttp/guzzle": "^7.8"
     },
     "require-dev": {
-        "pestphp/pest": "^1.23.6|^2.0",
+        "pestphp/pest": "^1.23|^2.0",
         "laravel/pint": "^1.0",
         "rector/rector": "^0.18.7",
         "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "guzzlehttp/guzzle": "^7.8"
     },
     "require-dev": {
-        "pestphp/pest": "^2.0",
+        "pestphp/pest": "^2.6",
         "laravel/pint": "^1.13",
         "rector/rector": "^0.18.7",
         "phpstan/phpstan": "^1.10",

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -1,12 +1,10 @@
 <?php
 
-describe('row', function () {
-    test('data can be stored', function () {
-        $response = tablestore()->table('testing_items')->insert([
-            // PrimaryKey::string('key', 'foo'),
-            // Attribute::string('value', 'bar'),
-        ]);
+test('data can be stored', function () {
+    $response = tablestore()->table('testing_items')->insert([
+        // PrimaryKey::string('key', 'foo'),
+        // Attribute::string('value', 'bar'),
+    ]);
 
-        expect($response)->toBeArray();
-    });
+    expect($response)->toBeArray();
 })->skip(! integrationTestEnabled(), 'integraion test not enabled');

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -1,14 +1,12 @@
 <?php
 
-beforeEach(function () {
-    //
+describe('row', function () {
+    test('data can be stored', function () {
+        $response = tablestore()->table('testing_items')->insert([
+            // PrimaryKey::string('key', 'foo'),
+            // Attribute::string('value', 'bar'),
+        ]);
+
+        expect($response)->toBeArray();
+    });
 })->skip(! integrationTestEnabled(), 'integraion test not enabled');
-
-test('data can be stored', function () {
-    $response = tablestore()->table('testing_items')->insert([
-        // PrimaryKey::string('key', 'foo'),
-        // Attribute::string('value', 'bar'),
-    ]);
-
-    expect($response)->toBeArray();
-});


### PR DESCRIPTION
The testing workflow ensures the package are being able to run on PHP version v8.0, v8.1 and v8.2; Pest 2 which is based on PHPUnit 10 is supported at least PHP v8.1+, so we need to be aware of writing tests not using features on v2.