### PR TITLE
Query data from table

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -3,6 +3,7 @@
 namespace Dew\Tablestore;
 
 use Dew\Tablestore\Responses\RowDecodableResponse;
+use Google\Protobuf\Internal\Message;
 use Protos\Condition;
 use Protos\GetRowRequest;
 use Protos\GetRowResponse;
@@ -256,13 +257,5 @@ class Builder
         $row = new RowWriter(new PlainbufferWriter, new Crc);
 
         return $row->writeHeader();
-    }
-
-    /**
-     * Make a new row reader.
-     */
-    protected function rowReader(string $buffer): RowReader
-    {
-        return new RowReader(new PlainbufferReader($buffer), new Crc);
     }
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -166,9 +166,9 @@ class Builder
      * Insert the rows to table.
      *
      * @param  \Dew\Tablestore\Cells\Cell[]  $rows
-     * @return array<string, mixed>
+     * @return \Dew\Tablestore\Responses\RowDecodableResponse<\Protos\PutRowResponse>
      */
-    public function insert(array $rows): array
+    public function insert(array $rows): RowDecodableResponse
     {
         $this->rows = $rows;
 
@@ -188,9 +188,9 @@ class Builder
     /**
      * Send the put row request to Tablestore.
      *
-     * @return array<string, mixed>
+     * @return \Dew\Tablestore\Responses\RowDecodableResponse<\Protos\PutRowResponse>
      */
-    protected function putRow(): array
+    protected function putRow(): RowDecodableResponse
     {
         $row = $this->rowWriter()->addRow($this->rows);
 
@@ -206,19 +206,9 @@ class Builder
         ]));
 
         $response = new PutRowResponse;
-        $response->mergeFromString(
-            $this->tablestore->send('/PutRow', $request)->getBody()->getContents()
-        );
+        $response->mergeFromString($this->tablestore->send('/PutRow', $request)->getBody()->getContents());
 
-        return [
-            'consumed' => [
-                'capacity_unit' => [
-                    'read' => $response->getConsumed()?->getCapacityUnit()?->getRead(),
-                    'write' => $response->getConsumed()?->getCapacityUnit()?->getWrite(),
-                ],
-            ],
-            'row' => $response->getRow() === '' ? null : $this->rowReader($response->getRow())->toArray(),
-        ];
+        return new RowDecodableResponse($response);
     }
 
     /**

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -31,6 +31,13 @@ class Builder
     protected int $returned = ReturnType::RT_PK;
 
     /**
+     * The list of column names to retrieve with.
+     *
+     * @var string[]
+     */
+    protected array $selects = [];
+
+    /**
      * The scoped primary keys.
      *
      * @var \Dew\Tablestore\Cells\Cell[]
@@ -116,6 +123,18 @@ class Builder
     public function returned(int $type): self
     {
         $this->returned = $type;
+
+        return $this;
+    }
+
+    /**
+     * Select a list of column name to retrieve with.
+     *
+     * @param  string[]  $columns
+     */
+    public function select(array $columns = []): self
+    {
+        $this->selects = $columns;
 
         return $this;
     }
@@ -213,6 +232,7 @@ class Builder
         $request = new GetRowRequest;
         $request->setTableName($this->table);
         $request->setPrimaryKey($row->getBuffer());
+        $request->setColumnsToGet($this->selects);
         $request->setMaxVersions($this->takes);
 
         $response = new GetRowResponse;

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -207,7 +207,7 @@ class Builder
         ]));
 
         $response = new PutRowResponse;
-        $response->mergeFromString($this->tablestore->send('/PutRow', $request)->getBody()->getContents());
+        $response->mergeFromString($this->send('/PutRow', $request));
 
         return new RowDecodableResponse($response);
     }
@@ -228,7 +228,7 @@ class Builder
         $request->setMaxVersions($this->takes);
 
         $response = new GetRowResponse;
-        $response->mergeFromString($this->tablestore->send('/GetRow', $request)->getBody()->getContents());
+        $response->mergeFromString($this->send('/GetRow', $request));
 
         return new RowDecodableResponse($response);
     }
@@ -257,5 +257,15 @@ class Builder
         $row = new RowWriter(new PlainbufferWriter, new Crc);
 
         return $row->writeHeader();
+    }
+
+    /**
+     * Communicate with Tablestore with the given message.
+     */
+    protected function send(string $endpoint, Message $message): string
+    {
+        return $this->tablestore->send($endpoint, $message)
+            ->getBody()
+            ->getContents();
     }
 }

--- a/src/Concerns/Conditionable.php
+++ b/src/Concerns/Conditionable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Dew\Tablestore\Concerns;
+
+trait Conditionable
+{
+    /**
+     * Execute callback when the condition is true.
+     *
+     * @param  callable(): mixed  $callback
+     */
+    protected function when(bool $condition, callable $callback): self
+    {
+        if ($condition) {
+            $callback();
+        }
+
+        return $this;
+    }
+}

--- a/src/Responses/RowDecodableResponse.php
+++ b/src/Responses/RowDecodableResponse.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Dew\Tablestore\Responses;
+
+use BadMethodCallException;
+use Dew\Tablestore\Crc;
+use Dew\Tablestore\PlainbufferReader;
+use Dew\Tablestore\RowReader;
+
+/**
+ * @template T of object
+ *
+ * @mixin T
+ */
+class RowDecodableResponse
+{
+    /**
+     * Create a row decoded response.
+     *
+     * @param  T  $response
+     */
+    public function __construct(
+        protected $response
+    ) {
+        //
+    }
+
+    /**
+     * The decoded row data.
+     *
+     * @return array<mixed>|null
+     */
+    public function getDecodedRow(): ?array
+    {
+        if (! method_exists($this->response, 'getRow')) {
+            throw new BadMethodCallException('Missing getRow method from the response.');
+        }
+
+        $buffer = $this->response->getRow();
+
+        if ($buffer === '') {
+            return null;
+        }
+
+        return $this->reader($buffer)->toArray();
+    }
+
+    /**
+     * Make a new reader for the given row buffer.
+     */
+    protected function reader(string $buffer): RowReader
+    {
+        return new RowReader(new PlainbufferReader($buffer), new Crc);
+    }
+
+    /**
+     * Proxy calling to the response.
+     *
+     * @param  array<int, mixed>  $arguments
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        $callback = [$this->response, $method];
+
+        if (is_callable($callback)) {
+            return call_user_func_array($callback, $arguments);
+        }
+
+        throw new BadMethodCallException(sprintf('Call to undefined method %s::%s()',
+            $this->response::class, $method
+        ));
+    }
+}

--- a/src/Responses/RowDecodableResponse.php
+++ b/src/Responses/RowDecodableResponse.php
@@ -8,7 +8,7 @@ use Dew\Tablestore\PlainbufferReader;
 use Dew\Tablestore\RowReader;
 
 /**
- * @template T of object
+ * @template T of \Google\Protobuf\Internal\Message
  *
  * @mixin T
  */

--- a/src/RowReader.php
+++ b/src/RowReader.php
@@ -190,7 +190,7 @@ class RowReader
         // When reaching the cell checksum tag, there is the last stage where
         // we can process the cell data. After validating the integrity of
         // the cell, we could confidently append it to the decoded data.
-        $this->data[$cell->name()] = $cell;
+        $this->append($cell);
 
         $this->rowChecksum = $this->checksum->char($checksum, $this->rowChecksum);
 
@@ -242,6 +242,26 @@ class RowReader
         }
 
         return $cell;
+    }
+
+    /**
+     * Append the cell to the decoded data.
+     */
+    protected function append(Cell $cell): self
+    {
+        // Since an attribute might contain multiple value versions, keeping
+        // a fixed data structure–a list ensures data consistency even if
+        // the one has only one version. The newer version comes first.
+        if ($cell instanceof Contracts\Attribute) {
+            $this->data[$cell->name()] ??= [];
+            $this->data[$cell->name()][] = $cell;
+
+            return $this;
+        }
+
+        $this->data[$cell->name()] = $cell;
+
+        return $this;
     }
 
     /**

--- a/src/RowWriter.php
+++ b/src/RowWriter.php
@@ -5,12 +5,15 @@ namespace Dew\Tablestore;
 use Dew\Tablestore\Cells\Attribute;
 use Dew\Tablestore\Cells\Cell;
 use Dew\Tablestore\Cells\Tag;
+use Dew\Tablestore\Concerns\Conditionable;
 use Dew\Tablestore\Contracts\Attribute as AttributeContract;
 use Dew\Tablestore\Contracts\CalculatesChecksum;
 use Dew\Tablestore\Contracts\PrimaryKey as PrimaryKeyContract;
 
 class RowWriter
 {
+    use Conditionable;
+
     /**
      * The row checksum.
      */
@@ -48,7 +51,7 @@ class RowWriter
 
         return $this->newRow()
             ->addPk($pks)
-            ->addAttr($attrs)
+            ->when($attrs !== [], fn (): self => $this->addAttr($attrs))
             ->addDeleteMarker()
             ->addRowChecksum($this->rowChecksum);
     }

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -26,7 +26,7 @@ test('data can be stored', function () {
         ->and($row['key'])->toBeInstanceOf(StringPrimaryKey::class)
         ->and($row['key']->name())->toBe($key->name())
         ->and($row['key']->value())->toBe($key->value());
-})->skip(! integrationTestEnabled(), 'integraion test not enabled');
+})->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('store data with timestamp', function () {
     $now = new DateTimeImmutable;
@@ -40,7 +40,7 @@ test('store data with timestamp', function () {
 
     expect($response->getConsumed()->getCapacityUnit()->getRead())->toBe(0)
         ->and($response->getConsumed()->getCapacityUnit()->getWrite())->toBe(1);
-})->skip(! integrationTestEnabled(), 'integraion test not enabled');
+})->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('data can be retrieved', function () {
     $response = tablestore()->table('testing_items')->where([
@@ -62,7 +62,7 @@ test('data can be retrieved', function () {
         ->and($row['string'][0]->value())->toBe('foo')
         ->and($row['binary'][0])->toBeInstanceOf(BinaryAttribute::class)
         ->and($row['binary'][0]->value())->toBe('bar');
-})->depends('data can be stored')->skip(! integrationTestEnabled(), 'integraion test not enabled');
+})->depends('data can be stored')->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('data retrieval with maximal versions', function () {
     $response = tablestore()->table('testing_items')->where([
@@ -75,7 +75,7 @@ test('data retrieval with maximal versions', function () {
         ->and($row['value'][0]->value())->toBe(200)
         ->and($row['value'][1])->toBeInstanceOf(IntegerAttribute::class)
         ->and($row['value'][1]->value())->toBe(100);
-})->depends('store data with timestamp')->skip(! integrationTestEnabled(), 'integraion test not enabled');
+})->depends('store data with timestamp')->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('data retrieval with selected columns', function () {
     $response = tablestore()->table('testing_items')
@@ -85,4 +85,4 @@ test('data retrieval with selected columns', function () {
     $row = $response->getDecodedRow();
     expect($row)->toBeArray()->toHaveKeys(['integer', 'string'])
         ->and($row)->not->toHaveKeys(['double', 'true', 'false', 'binary']);
-})->depends('data can be stored')->skip(! integrationTestEnabled(), 'integraion test not enabled');
+})->depends('data can be stored')->skip(! integrationTestEnabled(), 'integration test not enabled');

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -46,7 +46,9 @@ test('data can be retrieved', function () {
     $response = tablestore()->table('testing_items')->where([
         PrimaryKey::string('key', 'foo'),
     ])->get();
+
     $row = $response->getDecodedRow();
+
     expect($response->getConsumed()->getCapacityUnit()->getRead())->toBe(1)
         ->and($response->getConsumed()->getCapacityUnit()->getWrite())->toBe(0)
         ->and($row)->toHaveKeys(['integer', 'double', 'true', 'false', 'string', 'binary'])
@@ -68,7 +70,9 @@ test('data retrieval with maximal versions', function () {
     $response = tablestore()->table('testing_items')->where([
         PrimaryKey::string('key', 'timestamps'),
     ])->take(2)->get();
+
     $row = $response->getDecodedRow();
+
     expect($row)->toBeArray()->toHaveKey('value')
         ->and($row['value'])->toBeArray()->toHaveCount(2)
         ->and($row['value'][0])->toBeInstanceOf(IntegerAttribute::class)
@@ -82,7 +86,9 @@ test('data retrieval with selected columns', function () {
         ->where([PrimaryKey::string('key', 'foo')])
         ->select(['integer', 'string'])
         ->get();
+
     $row = $response->getDecodedRow();
+
     expect($row)->toBeArray()->toHaveKeys(['integer', 'string'])
         ->and($row)->not->toHaveKeys(['double', 'true', 'false', 'binary']);
 })->depends('data can be stored')->skip(! integrationTestEnabled(), 'integration test not enabled');

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -1,6 +1,11 @@
 <?php
 
 use Dew\Tablestore\Attribute;
+use Dew\Tablestore\Cells\BinaryAttribute;
+use Dew\Tablestore\Cells\BooleanAttribute;
+use Dew\Tablestore\Cells\DoubleAttribute;
+use Dew\Tablestore\Cells\IntegerAttribute;
+use Dew\Tablestore\Cells\StringAttribute;
 use Dew\Tablestore\PrimaryKey;
 
 test('data can be stored', function () {
@@ -38,3 +43,41 @@ test('store data with timestamp', function () {
         ->and($response['consumed']['capacity_unit']['read'])->toBe(0)
         ->and($response['consumed']['capacity_unit']['write'])->toBe(1);
 })->skip(! integrationTestEnabled(), 'integraion test not enabled');
+
+test('data can be retrieved', function () {
+    $response = tablestore()->table('testing_items')->where([
+        PrimaryKey::string('key', 'foo'),
+    ])->get();
+
+    expect($response)->toBeArray()
+        ->and($response)->toHaveKeys(['consumed', 'row'])
+        ->and($response['consumed']['capacity_unit']['read'])->toBe(1)
+        ->and($response['consumed']['capacity_unit']['write'])->toBe(0)
+        ->and($response['row'])->toHaveKeys(['integer', 'double', 'true', 'false', 'string', 'binary'])
+        ->and($response['row']['integer'][0])->toBeInstanceOf(IntegerAttribute::class)
+        ->and($response['row']['integer'][0]->value())->toBe(100)
+        ->and($response['row']['double'][0])->toBeInstanceOf(DoubleAttribute::class)
+        ->and($response['row']['double'][0]->value())->toBe(3.14)
+        ->and($response['row']['true'][0])->toBeInstanceOf(BooleanAttribute::class)
+        ->and($response['row']['true'][0]->value())->toBe(true)
+        ->and($response['row']['false'][0])->toBeInstanceOf(BooleanAttribute::class)
+        ->and($response['row']['false'][0]->value())->toBe(false)
+        ->and($response['row']['string'][0])->toBeInstanceOf(StringAttribute::class)
+        ->and($response['row']['string'][0]->value())->toBe('foo')
+        ->and($response['row']['binary'][0])->toBeInstanceOf(BinaryAttribute::class)
+        ->and($response['row']['binary'][0]->value())->toBe('bar');
+})->depends('data can be stored')->skip(! integrationTestEnabled(), 'integraion test not enabled');
+
+test('data retrieval with maximal versions', function () {
+    $response = tablestore()->table('testing_items')->where([
+        PrimaryKey::string('key', 'timestamps'),
+    ])->take(2)->get();
+
+    expect($response)->toBeArray()
+        ->and($response)->toHaveKeys(['consumed', 'row'])
+        ->and($response['row']['value'])->toBeArray()->toHaveCount(2)
+        ->and($response['row']['value'][0])->toBeInstanceOf(IntegerAttribute::class)
+        ->and($response['row']['value'][0]->value())->toBe(200)
+        ->and($response['row']['value'][1])->toBeInstanceOf(IntegerAttribute::class)
+        ->and($response['row']['value'][1]->value())->toBe(100);
+})->depends('store data with timestamp')->skip(! integrationTestEnabled(), 'integraion test not enabled');

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -48,38 +48,35 @@ test('data can be retrieved', function () {
     $response = tablestore()->table('testing_items')->where([
         PrimaryKey::string('key', 'foo'),
     ])->get();
-
-    expect($response)->toBeArray()
-        ->and($response)->toHaveKeys(['consumed', 'row'])
-        ->and($response['consumed']['capacity_unit']['read'])->toBe(1)
-        ->and($response['consumed']['capacity_unit']['write'])->toBe(0)
-        ->and($response['row'])->toHaveKeys(['integer', 'double', 'true', 'false', 'string', 'binary'])
-        ->and($response['row']['integer'][0])->toBeInstanceOf(IntegerAttribute::class)
-        ->and($response['row']['integer'][0]->value())->toBe(100)
-        ->and($response['row']['double'][0])->toBeInstanceOf(DoubleAttribute::class)
-        ->and($response['row']['double'][0]->value())->toBe(3.14)
-        ->and($response['row']['true'][0])->toBeInstanceOf(BooleanAttribute::class)
-        ->and($response['row']['true'][0]->value())->toBe(true)
-        ->and($response['row']['false'][0])->toBeInstanceOf(BooleanAttribute::class)
-        ->and($response['row']['false'][0]->value())->toBe(false)
-        ->and($response['row']['string'][0])->toBeInstanceOf(StringAttribute::class)
-        ->and($response['row']['string'][0]->value())->toBe('foo')
-        ->and($response['row']['binary'][0])->toBeInstanceOf(BinaryAttribute::class)
-        ->and($response['row']['binary'][0]->value())->toBe('bar');
+    $row = $response->getDecodedRow();
+    expect($response->getConsumed()->getCapacityUnit()->getRead())->toBe(1)
+        ->and($response->getConsumed()->getCapacityUnit()->getWrite())->toBe(0)
+        ->and($row)->toHaveKeys(['integer', 'double', 'true', 'false', 'string', 'binary'])
+        ->and($row['integer'][0])->toBeInstanceOf(IntegerAttribute::class)
+        ->and($row['integer'][0]->value())->toBe(100)
+        ->and($row['double'][0])->toBeInstanceOf(DoubleAttribute::class)
+        ->and($row['double'][0]->value())->toBe(3.14)
+        ->and($row['true'][0])->toBeInstanceOf(BooleanAttribute::class)
+        ->and($row['true'][0]->value())->toBe(true)
+        ->and($row['false'][0])->toBeInstanceOf(BooleanAttribute::class)
+        ->and($row['false'][0]->value())->toBe(false)
+        ->and($row['string'][0])->toBeInstanceOf(StringAttribute::class)
+        ->and($row['string'][0]->value())->toBe('foo')
+        ->and($row['binary'][0])->toBeInstanceOf(BinaryAttribute::class)
+        ->and($row['binary'][0]->value())->toBe('bar');
 })->depends('data can be stored')->skip(! integrationTestEnabled(), 'integraion test not enabled');
 
 test('data retrieval with maximal versions', function () {
     $response = tablestore()->table('testing_items')->where([
         PrimaryKey::string('key', 'timestamps'),
     ])->take(2)->get();
-
-    expect($response)->toBeArray()
-        ->and($response)->toHaveKeys(['consumed', 'row'])
-        ->and($response['row']['value'])->toBeArray()->toHaveCount(2)
-        ->and($response['row']['value'][0])->toBeInstanceOf(IntegerAttribute::class)
-        ->and($response['row']['value'][0]->value())->toBe(200)
-        ->and($response['row']['value'][1])->toBeInstanceOf(IntegerAttribute::class)
-        ->and($response['row']['value'][1]->value())->toBe(100);
+    $row = $response->getDecodedRow();
+    expect($row)->toBeArray()->toHaveKey('value')
+        ->and($row['value'])->toBeArray()->toHaveCount(2)
+        ->and($row['value'][0])->toBeInstanceOf(IntegerAttribute::class)
+        ->and($row['value'][0]->value())->toBe(200)
+        ->and($row['value'][1])->toBeInstanceOf(IntegerAttribute::class)
+        ->and($row['value'][1]->value())->toBe(100);
 })->depends('store data with timestamp')->skip(! integrationTestEnabled(), 'integraion test not enabled');
 
 test('data retrieval with selected columns', function () {
@@ -87,8 +84,7 @@ test('data retrieval with selected columns', function () {
         ->where([PrimaryKey::string('key', 'foo')])
         ->select(['integer', 'string'])
         ->get();
-
-    expect($response)->toBeArray()->toHaveKeys(['consumed', 'row'])
-        ->and($response['row'])->toHaveKeys(['integer', 'string'])
-        ->and($response['row'])->not->toHaveKeys(['double', 'true', 'false', 'binary']);
+    $row = $response->getDecodedRow();
+    expect($row)->toBeArray()->toHaveKeys(['integer', 'string'])
+        ->and($row)->not->toHaveKeys(['double', 'true', 'false', 'binary']);
 })->depends('data can be stored')->skip(! integrationTestEnabled(), 'integraion test not enabled');

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -81,3 +81,14 @@ test('data retrieval with maximal versions', function () {
         ->and($response['row']['value'][1])->toBeInstanceOf(IntegerAttribute::class)
         ->and($response['row']['value'][1]->value())->toBe(100);
 })->depends('store data with timestamp')->skip(! integrationTestEnabled(), 'integraion test not enabled');
+
+test('data retrieval with selected columns', function () {
+    $response = tablestore()->table('testing_items')
+        ->where([PrimaryKey::string('key', 'foo')])
+        ->select(['integer', 'string'])
+        ->get();
+
+    expect($response)->toBeArray()->toHaveKeys(['consumed', 'row'])
+        ->and($response['row'])->toHaveKeys(['integer', 'string'])
+        ->and($response['row'])->not->toHaveKeys(['double', 'true', 'false', 'binary']);
+})->depends('data can be stored')->skip(! integrationTestEnabled(), 'integraion test not enabled');

--- a/tests/RowTest.php
+++ b/tests/RowTest.php
@@ -52,7 +52,7 @@ it('has attribute', function ($attr) {
     $result = $reader->toArray();
     expect($result)->toBeArray()->and($result)->toHaveKey($attr->name());
     /** @var \Dew\Tablestore\Cells\Cell $cell */
-    $cell = $result[$attr->name()];
+    $cell = $result[$attr->name()][0];
     expect($cell)->toBeInstanceOf(Cell::class)
         ->and($cell)->toBeInstanceOf(AttributeContract::class)
         ->and($cell->name())->toBe($attr->name())
@@ -91,7 +91,7 @@ test('add row', function () {
     expect($result)->toBeArray()
         ->and($result)->toHaveKeys(['key', 'value'])
         ->and($result['key'])->toBeInstanceOf(PrimaryKeyContract::class)
-        ->and($result['value'])->toBeInstanceOf(AttributeContract::class);
+        ->and($result['value'][0])->toBeInstanceOf(AttributeContract::class);
 });
 
 test('attribute with timestamp', function () {
@@ -105,6 +105,6 @@ test('attribute with timestamp', function () {
     $result = $reader->toArray();
     expect($result)->toBeArray()
         ->and($result)->toHaveKey('value')
-        ->and($result['value'])->toBeInstanceOf(AttributeContract::class)
-        ->and($result['value']->getTimestamp())->toBe((int) $now->format('Uv'));
+        ->and($result['value'][0])->toBeInstanceOf(AttributeContract::class)
+        ->and($result['value'][0]->getTimestamp())->toBe((int) $now->format('Uv'));
 });


### PR DESCRIPTION
Data querying API provides a SQL-like interface, making it intuitive and letting you feel like home from day one.

Let's say getting the values from the **users** table. The primary key is named **email**, and the expected value is _im@zhineng.li_.

```php
$tablestore->table('users')->where([
    PrimaryKey::string('email', 'im@zhineng.li'),
])->get();
```

Feeling comfortable, don't you? The result contains all the attribute values by default. If you want to limit the attributes returned from Tablestore that you mostly care about, simply chaining the `select` method.

```php
$tablestore->table('users')->where([
    PrimaryKey::string('email', 'im@zhineng.li'),
])->select([
    'name', 'age',
    'email',  // Also supports the primary key
])->get();
```

Tablestore supports multiple data versions in an attribute that is convenient if you need to record a history of the value. If you don't specify the maximal versions to retrieve, we conventionally retrieve one version for you.

The `take` method accepts the maximal versions Tablestore returns.

```php
$tablestore->table('users')->where([
    PrimaryKey::string('email', 'im@zhineng.li'),
])->take(2)->get();
```

Beyond the data querying API, we modified the response type for `insert` and `get` interfaces. Instead of constructing the response array from each communication with Tablestore, we wrap a decorator to decode the Plainbuffer if a response is needed or return the raw message response from Google Protobuf.