### PR TITLE
Modify the existing attributes in table

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -2,8 +2,10 @@
 
 namespace Dew\Tablestore;
 
+use DateTimeInterface;
 use Dew\Tablestore\Cells\BinaryAttribute;
 use Dew\Tablestore\Cells\BooleanAttribute;
+use Dew\Tablestore\Cells\DeleteAttribute;
 use Dew\Tablestore\Cells\DoubleAttribute;
 use Dew\Tablestore\Cells\IntegerAttribute;
 use Dew\Tablestore\Cells\StringAttribute;
@@ -50,6 +52,16 @@ class Attribute
     public static function binary(string $name, string $value): BinaryAttribute
     {
         return new BinaryAttribute($name, $value);
+    }
+
+    /**
+     * Create an awaiting deletion attribute.
+     */
+    public static function delete(string $name, DateTimeInterface|int $timestamp = null): DeleteAttribute
+    {
+        $attribute = new DeleteAttribute($name);
+
+        return $timestamp === null ? $attribute->all() : $attribute->version($timestamp);
     }
 
     /**

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -23,6 +23,22 @@ class Attribute
     }
 
     /**
+     * Create an integer attribute with incrementing value.
+     */
+    public static function increment(string $name, int $increment = 1): IntegerAttribute
+    {
+        return (new IntegerAttribute($name, $increment))->increment();
+    }
+
+    /**
+     * Create an integer attribute with decrementing value.
+     */
+    public static function decrement(string $name, int $decrement = 1): IntegerAttribute
+    {
+        return (new IntegerAttribute($name, -$decrement))->increment();
+    }
+
+    /**
      * Create a double attribute.
      */
     public static function double(string $name, float $value): DoubleAttribute

--- a/src/Cells/Attribute.php
+++ b/src/Cells/Attribute.php
@@ -14,6 +14,11 @@ abstract class Attribute extends Cell implements AttributeContract
     protected ?int $timestamp = null;
 
     /**
+     * The operation applied to the cell.
+     */
+    protected ?int $operation = null;
+
+    /**
      * Set the timestamp of the cell.
      */
     public function setTimestamp(DateTimeInterface|int $timestamp): self
@@ -36,6 +41,24 @@ abstract class Attribute extends Cell implements AttributeContract
     }
 
     /**
+     * Set operation to the cell.
+     */
+    protected function setOperation(int $type): self
+    {
+        $this->operation = $type;
+
+        return $this;
+    }
+
+    /**
+     * Get the operation applied to the cell.
+     */
+    public function getOperation(): ?int
+    {
+        return $this->operation;
+    }
+
+    /**
      * Calculate checksum for the cell.
      */
     public function getChecksumBy(CalculatesChecksum $calculator): int
@@ -43,7 +66,11 @@ abstract class Attribute extends Cell implements AttributeContract
         $checksum = parent::getChecksumBy($calculator);
 
         if ($this->getTimestamp() !== null) {
-            return $calculator->int64($this->getTimestamp(), $checksum);
+            $checksum = $calculator->int64($this->getTimestamp(), $checksum);
+        }
+
+        if ($this->getOperation() !== null) {
+            return $calculator->char($this->getOperation(), $checksum);
         }
 
         return $checksum;

--- a/src/Cells/BinaryAttribute.php
+++ b/src/Cells/BinaryAttribute.php
@@ -2,7 +2,9 @@
 
 namespace Dew\Tablestore\Cells;
 
-class BinaryAttribute extends Attribute
+use Dew\Tablestore\Contracts\HasValue;
+
+class BinaryAttribute extends Attribute implements HasValue
 {
     use IsBinaryCell;
 }

--- a/src/Cells/BinaryPrimaryKey.php
+++ b/src/Cells/BinaryPrimaryKey.php
@@ -2,9 +2,10 @@
 
 namespace Dew\Tablestore\Cells;
 
+use Dew\Tablestore\Contracts\HasValue;
 use Dew\Tablestore\Contracts\PrimaryKey;
 
-class BinaryPrimaryKey extends Cell implements PrimaryKey
+class BinaryPrimaryKey extends Cell implements HasValue, PrimaryKey
 {
     use IsBinaryCell;
 }

--- a/src/Cells/BooleanAttribute.php
+++ b/src/Cells/BooleanAttribute.php
@@ -2,7 +2,9 @@
 
 namespace Dew\Tablestore\Cells;
 
-class BooleanAttribute extends Attribute
+use Dew\Tablestore\Contracts\HasValue;
+
+class BooleanAttribute extends Attribute implements HasValue
 {
     use IsBooleanCell;
 }

--- a/src/Cells/Cell.php
+++ b/src/Cells/Cell.php
@@ -57,8 +57,20 @@ abstract class Cell
     {
         $checksum = $calculator->string($this->name(), 0);
 
+        if (! $this->shouldChecksumValue()) {
+            return $checksum;
+        }
+
         $checksum = $calculator->char($this->type(), $checksum);
 
         return $this->getValueChecksumBy($calculator, $checksum);
+    }
+
+    /**
+     * Determine if the cell value should be included in checksum.
+     */
+    protected function shouldChecksumValue(): bool
+    {
+        return ! $this instanceof DeleteAttribute;
     }
 }

--- a/src/Cells/Cell.php
+++ b/src/Cells/Cell.php
@@ -3,8 +3,7 @@
 namespace Dew\Tablestore\Cells;
 
 use Dew\Tablestore\Contracts\CalculatesChecksum;
-use Dew\Tablestore\PlainbufferReader;
-use Dew\Tablestore\PlainbufferWriter;
+use Dew\Tablestore\Contracts\HasValue;
 
 abstract class Cell
 {
@@ -20,35 +19,6 @@ abstract class Cell
     {
         return $this->name;
     }
-
-    /**
-     * The value of the cell.
-     */
-    abstract public function value(): mixed;
-
-    /**
-     * The value type of the cell.
-     */
-    abstract public function type(): int;
-
-    /**
-     * Get value from the formatted value in buffer.
-     */
-    abstract public static function fromFormattedValue(PlainbufferReader $buffer): mixed;
-
-    /**
-     * Build formatted value to buffer.
-     *
-     * formatted_value = value_type value_len value_data
-     * value_type = int8
-     * value_len = int32
-     */
-    abstract public function toFormattedValue(PlainbufferWriter $buffer): void;
-
-    /**
-     * Calculate checksum for the cell value.
-     */
-    abstract public function getValueChecksumBy(CalculatesChecksum $calculator, int $checksum): int;
 
     /**
      * Calculate checksum for the cell.
@@ -68,9 +38,11 @@ abstract class Cell
 
     /**
      * Determine if the cell value should be included in checksum.
+     *
+     * @phpstan-assert-if-true \Dew\Tablestore\Contracts\HasValue $this
      */
     protected function shouldChecksumValue(): bool
     {
-        return ! $this instanceof DeleteAttribute;
+        return $this instanceof HasValue;
     }
 }

--- a/src/Cells/DeleteAttribute.php
+++ b/src/Cells/DeleteAttribute.php
@@ -3,10 +3,6 @@
 namespace Dew\Tablestore\Cells;
 
 use DateTimeInterface;
-use Dew\Tablestore\Contracts\CalculatesChecksum;
-use Dew\Tablestore\PlainbufferReader;
-use Dew\Tablestore\PlainbufferWriter;
-use LogicException;
 
 class DeleteAttribute extends Attribute
 {
@@ -44,49 +40,5 @@ class DeleteAttribute extends Attribute
         $this->setTimestamp($timestamp);
 
         return $this;
-    }
-
-    /**
-     * The value of the cell.
-     */
-    public function value(): mixed
-    {
-        return null;
-    }
-
-    /**
-     * The value type of the cell.
-     */
-    public function type(): int
-    {
-        throw new LogicException('Awaiting deletion attribute does not contain a real value.');
-    }
-
-    /**
-     * Get value from the formatted value in buffer.
-     */
-    public static function fromFormattedValue(PlainbufferReader $buffer): mixed
-    {
-        throw new LogicException('Awaiting deletion attribute does not contain a real value.');
-    }
-
-    /**
-     * Build formatted value to buffer.
-     *
-     * formatted_value = value_type value_len value_data
-     * value_type = int8
-     * value_len = int32
-     */
-    public function toFormattedValue(PlainbufferWriter $buffer): void
-    {
-        throw new LogicException('Awaiting deletion attribute does not contain a real value.');
-    }
-
-    /**
-     * Calculate checksum for the cell value.
-     */
-    public function getValueChecksumBy(CalculatesChecksum $calculator, int $checksum): int
-    {
-        throw new LogicException('Awaiting deletion attribute does not contain a real value.');
     }
 }

--- a/src/Cells/DeleteAttribute.php
+++ b/src/Cells/DeleteAttribute.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Dew\Tablestore\Cells;
+
+use DateTimeInterface;
+use Dew\Tablestore\Contracts\CalculatesChecksum;
+use Dew\Tablestore\PlainbufferReader;
+use Dew\Tablestore\PlainbufferWriter;
+use LogicException;
+
+class DeleteAttribute extends Attribute
+{
+    /**
+     * The operation applied to the cell.
+     */
+    protected ?int $operation = Operation::DELETE_ALL_VERSIONS;
+
+    /**
+     * Create an awaiting deletion attribute.
+     */
+    public function __construct(
+        protected string $name
+    ) {
+        //
+    }
+
+    /**
+     * Delete all the versions.
+     */
+    public function all(): self
+    {
+        $this->operation = Operation::DELETE_ALL_VERSIONS;
+        $this->timestamp = null;
+
+        return $this;
+    }
+
+    /**
+     * Delete the given version.
+     */
+    public function version(DateTimeInterface|int $timestamp): self
+    {
+        $this->operation = Operation::DELETE_ONE_VERSION;
+        $this->setTimestamp($timestamp);
+
+        return $this;
+    }
+
+    /**
+     * The value of the cell.
+     */
+    public function value(): mixed
+    {
+        return null;
+    }
+
+    /**
+     * The value type of the cell.
+     */
+    public function type(): int
+    {
+        throw new LogicException('Awaiting deletion attribute does not contain a real value.');
+    }
+
+    /**
+     * Get value from the formatted value in buffer.
+     */
+    public static function fromFormattedValue(PlainbufferReader $buffer): mixed
+    {
+        throw new LogicException('Awaiting deletion attribute does not contain a real value.');
+    }
+
+    /**
+     * Build formatted value to buffer.
+     *
+     * formatted_value = value_type value_len value_data
+     * value_type = int8
+     * value_len = int32
+     */
+    public function toFormattedValue(PlainbufferWriter $buffer): void
+    {
+        throw new LogicException('Awaiting deletion attribute does not contain a real value.');
+    }
+
+    /**
+     * Calculate checksum for the cell value.
+     */
+    public function getValueChecksumBy(CalculatesChecksum $calculator, int $checksum): int
+    {
+        throw new LogicException('Awaiting deletion attribute does not contain a real value.');
+    }
+}

--- a/src/Cells/DoubleAttribute.php
+++ b/src/Cells/DoubleAttribute.php
@@ -2,7 +2,9 @@
 
 namespace Dew\Tablestore\Cells;
 
-class DoubleAttribute extends Attribute
+use Dew\Tablestore\Contracts\HasValue;
+
+class DoubleAttribute extends Attribute implements HasValue
 {
     use IsDoubleCell;
 }

--- a/src/Cells/IntegerAttribute.php
+++ b/src/Cells/IntegerAttribute.php
@@ -2,7 +2,9 @@
 
 namespace Dew\Tablestore\Cells;
 
-class IntegerAttribute extends Attribute
+use Dew\Tablestore\Contracts\HasValue;
+
+class IntegerAttribute extends Attribute implements HasValue
 {
     use IsIntegerCell;
 }

--- a/src/Cells/IntegerAttribute.php
+++ b/src/Cells/IntegerAttribute.php
@@ -7,4 +7,14 @@ use Dew\Tablestore\Contracts\HasValue;
 class IntegerAttribute extends Attribute implements HasValue
 {
     use IsIntegerCell;
+
+    /**
+     * Set increment operation.
+     */
+    public function increment(): self
+    {
+        $this->setOperation(Operation::INCREMENT);
+
+        return $this;
+    }
 }

--- a/src/Cells/IntegerPrimaryKey.php
+++ b/src/Cells/IntegerPrimaryKey.php
@@ -2,9 +2,10 @@
 
 namespace Dew\Tablestore\Cells;
 
+use Dew\Tablestore\Contracts\HasValue;
 use Dew\Tablestore\Contracts\PrimaryKey;
 
-class IntegerPrimaryKey extends Cell implements PrimaryKey
+class IntegerPrimaryKey extends Cell implements HasValue, PrimaryKey
 {
     use IsIntegerCell;
 }

--- a/src/Cells/Operation.php
+++ b/src/Cells/Operation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Dew\Tablestore\Cells;
+
+class Operation
+{
+    public const DELETE_ALL_VERSIONS = 0x1;
+
+    public const DELETE_ONE_VERSION = 0x3;
+
+    public const INCREMENT = 0x4;
+}

--- a/src/Cells/StringAttribute.php
+++ b/src/Cells/StringAttribute.php
@@ -2,7 +2,9 @@
 
 namespace Dew\Tablestore\Cells;
 
-class StringAttribute extends Attribute
+use Dew\Tablestore\Contracts\HasValue;
+
+class StringAttribute extends Attribute implements HasValue
 {
     use IsStringCell;
 }

--- a/src/Cells/StringPrimaryKey.php
+++ b/src/Cells/StringPrimaryKey.php
@@ -2,9 +2,10 @@
 
 namespace Dew\Tablestore\Cells;
 
+use Dew\Tablestore\Contracts\HasValue;
 use Dew\Tablestore\Contracts\PrimaryKey;
 
-class StringPrimaryKey extends Cell implements PrimaryKey
+class StringPrimaryKey extends Cell implements HasValue, PrimaryKey
 {
     use IsStringCell;
 }

--- a/src/Contracts/HasValue.php
+++ b/src/Contracts/HasValue.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Dew\Tablestore\Contracts;
+
+use Dew\Tablestore\PlainbufferReader;
+use Dew\Tablestore\PlainbufferWriter;
+
+interface HasValue
+{
+    /**
+     * The value.
+     */
+    public function value(): mixed;
+
+    /**
+     * The value type.
+     */
+    public function type(): int;
+
+    /**
+     * Get value from the formatted value in buffer.
+     */
+    public static function fromFormattedValue(PlainbufferReader $buffer): mixed;
+
+    /**
+     * Build formatted value to buffer.
+     *
+     * formatted_value = value_type value_len value_data
+     * value_type = int8
+     * value_len = int32
+     */
+    public function toFormattedValue(PlainbufferWriter $buffer): void;
+
+    /**
+     * Calculate checksum for the value.
+     */
+    public function getValueChecksumBy(CalculatesChecksum $calculator, int $checksum): int;
+}

--- a/src/RowWriter.php
+++ b/src/RowWriter.php
@@ -124,6 +124,10 @@ class RowWriter
             $this->addCellValue($cell);
         }
 
+        if ($cell instanceof Attribute && $cell->getOperation() !== null) {
+            $this->addCellOp($cell->getOperation());
+        }
+
         if ($cell instanceof Attribute && $cell->getTimestamp() !== null) {
             $this->addCellTs($cell->getTimestamp());
         }
@@ -176,6 +180,23 @@ class RowWriter
     {
         $this->buffer->writeChar(Tag::CELL_TS);
         $this->buffer->writeLittleEndian64($timestamp);
+
+        return $this;
+    }
+
+    /**
+     * Encode the cell operation.
+     *
+     * cell_op = tag_cell_op cell_op_value
+     * cell_op_value = delete_all_version | delete_one_version | increment
+     * delete_all_version = 0x01 (1byte)
+     * delete_one_version = 0x03 (1byte)
+     * increment = 0x04 (1byte)
+     */
+    public function addCellOp(int $operation): self
+    {
+        $this->buffer->writeChar(Tag::CELL_OP);
+        $this->buffer->writeChar($operation);
 
         return $this;
     }

--- a/src/RowWriter.php
+++ b/src/RowWriter.php
@@ -8,6 +8,7 @@ use Dew\Tablestore\Cells\Tag;
 use Dew\Tablestore\Concerns\Conditionable;
 use Dew\Tablestore\Contracts\Attribute as AttributeContract;
 use Dew\Tablestore\Contracts\CalculatesChecksum;
+use Dew\Tablestore\Contracts\HasValue;
 use Dew\Tablestore\Contracts\PrimaryKey as PrimaryKeyContract;
 
 class RowWriter
@@ -120,7 +121,7 @@ class RowWriter
 
         $this->addCellName($cell);
 
-        if ($cell->value() !== null) {
+        if ($cell instanceof HasValue) {
             $this->addCellValue($cell);
         }
 
@@ -161,7 +162,7 @@ class RowWriter
      *
      * cell_value = tag_cell_value formatted_value
      */
-    public function addCellValue(Cell $cell): self
+    public function addCellValue(HasValue $cell): self
     {
         $this->buffer->writeChar(Tag::CELL_VALUE);
 

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -92,3 +92,20 @@ test('data retrieval with selected columns', function () {
     expect($row)->toBeArray()->toHaveKeys(['integer', 'string'])
         ->and($row)->not->toHaveKeys(['double', 'true', 'false', 'binary']);
 })->depends('data can be stored')->skip(! integrationTestEnabled(), 'integration test not enabled');
+
+test('data can be updated', function () {
+    $response = tablestore()->table('testing_items')
+        ->where([PrimaryKey::string('key', 'foo')])
+        ->update([
+            Attribute::integer('integer', 200),
+            Attribute::double('double', 2.71828),
+            Attribute::boolean('true', false),
+            Attribute::boolean('false', true),
+            Attribute::string('string', 'hello'),
+            Attribute::binary('binary', 'world'),
+        ]);
+
+    expect($response->getConsumed()->getCapacityUnit()->getRead())->toBe(0)
+        ->and($response->getConsumed()->getCapacityUnit()->getWrite())->toBe(1)
+        ->and($response->getDecodedRow())->toBeNull();
+})->skip(! integrationTestEnabled(), 'integration test not enabled');


### PR DESCRIPTION
Update is one of the basic data manipulation operations in a database. You could not live without it. The pull request implements a fluent and expressive API to let you easily modify the attribute values in a table.

## Update the Attribute Values

Like inserting new data into a table, you need to scope with the primary key of the attributes you want to modify. Let's say you might want to update a note by the ID.

```php
$tablestore->table('notes')->where([
    PrimaryKey::integer('id', 1),
])->update([
    Attribute::string('body', 'Today is sunny.'),
]);
```

When modifying attributes for a key that does not exist, Tablestore performs an insert operation instead of an update. That helps you easily extend your data structure to suit your needs.

## Row Existence Expectation

In a critical situation, you want to guarantee the data exists before modifying it, and you could chain with the **expect** API. The ignored row existence expectation would be applied by default if not specified.

Value expectation is a more practical way to keep data accuracy that is not supported currently. We will implement it later on the other pull request.

```php
$tablestore->table('notes')->where([
    PrimaryKey::integer('id', 1),
])->expectExists()->update([
    Attribute::string('body', 'Today is sunny.'),
]);
```

## Delete All Value Versions

For some applications, such as blogging platforms, maintaining an editing history sounds like a great idea to prevent data loss and have different versions that could be easily rolleback to.

Here, we introduce a helper attribute to elegantly and expressively delete the value. The awaiting deletion attribute is not an attribute that contains a real value. It helps you delete all the value versions and remove the attribute from the row.

```php
$tablestore->table('entries')->where([
    PrimaryKey::string('slug', 'hello-world'),
])->update([
    Attribute::delete('contents'),
]);
```

## Delete Specific Value Version

Removing a whole attribute data is scary. You might only want to remove the specific version of it, and we got you covered. Specify the data version in milliseconds you want to remove, and you're good to go.

```php
$tablestore->table('users')->where([
    PrimaryKey::string('email', 'im@zhineng.li'),
])->update([
    Attribute::delete('name')->version($timestamp = 1700000000000),
]);
```

## Increment & Decrement

Tablestore natively supports atomic counters. All you need is to specify the attribute name. You might want to customize the amount the value should be incremented, and pass it to the second argument.

```php
$tablestore->table('entries')->where([
    PrimaryKey::string('slug', 'awesome-tablestore'),
])->update([
    Attribute::increment('views'),
]);

$tablestore->table('entries')->where([
    PrimaryKey::string('slug', 'awesome-tablestore'),
])->update([
    Attribute::increment('views', 5),
]);

$tablestore->table('entries')->where([
    PrimaryKey::string('slug', 'awesome-tablestore'),
])->update([
    Attribute::decrement('views'),
]);

$tablestore->table('entries')->where([
    PrimaryKey::string('slug', 'awesome-tablestore'),
])->update([
    Attribute::decrement('views', 5),
]);
```