### PR TITLE
Delete row from table

### DIFF
--- a/src/RowWriter.php
+++ b/src/RowWriter.php
@@ -53,7 +53,20 @@ class RowWriter
         return $this->newRow()
             ->addPk($pks)
             ->when($attrs !== [], fn (): self => $this->addAttr($attrs))
-            ->addDeleteMarker()
+            ->addDeleteMarker(false)
+            ->addRowChecksum($this->rowChecksum);
+    }
+
+    /**
+     * Encode the row for deletion.
+     *
+     * @param  (\Dew\Tablestore\Cells\Cell&\Dew\Tablestore\Contracts\PrimaryKey)[]  $pks
+     */
+    public function deleteRow(array $pks): self
+    {
+        return $this->newRow()
+            ->addPk($pks)
+            ->addDeleteMarker(true)
             ->addRowChecksum($this->rowChecksum);
     }
 
@@ -218,12 +231,13 @@ class RowWriter
     /**
      * Encode the delete marker.
      */
-    public function addDeleteMarker(): self
+    public function addDeleteMarker(bool $isDeleteRow): self
     {
-        // TODO: Determine if the row contains delete request.
-        $delete = (int) false;
+        if ($isDeleteRow) {
+            $this->buffer->writeChar(Tag::DELETE_MARKER);
+        }
 
-        $this->rowChecksum = $this->checksum->char($delete, $this->rowChecksum);
+        $this->rowChecksum = $this->checksum->char((int) $isDeleteRow, $this->rowChecksum);
 
         return $this;
     }

--- a/tests/Integration/RowTest.php
+++ b/tests/Integration/RowTest.php
@@ -195,3 +195,24 @@ test('update with increment operation', function () {
         ->and($row['value'][0])->toBeInstanceOf(IntegerAttribute::class)
         ->and($row['value'][0]->value())->toBe(2);
 })->skip(! integrationTestEnabled(), 'integration test not enabled');
+
+test('delete removes the row', function () {
+    // prepare the testing data
+    tablestore()->table('testing_items')->insert([
+        $key = PrimaryKey::string('key', 'test-delete'),
+        Attribute::string('value', 'foo'),
+    ]);
+
+    // ensure the data is existing
+    $response = tablestore()->table('testing_items')->where([$key])->get();
+    expect($response->getDecodedRow())->toBeArray()->toHaveKey('value');
+
+    // delete the row
+    $response = tablestore()->table('testing_items')->where([$key])->delete();
+    expect($response->getConsumed()->getCapacityUnit()->getRead())->toBe(0)
+        ->and($response->getConsumed()->getCapacityUnit()->getRead())->toBe(0);
+
+    // ensure the data is missing
+    $response = tablestore()->table('testing_items')->where([$key])->get();
+    expect($response->getDecodedRow())->toBeNull();
+})->skip(! integrationTestEnabled(), 'integration test not enabled');


### PR DESCRIPTION
The pull request implements the row deletion API and secures the `where` method with only primary keys that can be provided. The **expect** API and **return** API are supported to customize the response result.

```php
$tablestore->table('entries')->where([
    PrimaryKey::string('slug', 'hello-world'),
])->delete();
```