### PR TITLE
Optional instance name

### DIFF
--- a/src/GuessInstanceName.php
+++ b/src/GuessInstanceName.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dew\Tablestore;
+
+use InvalidArgumentException;
+
+class GuessInstanceName
+{
+    /**
+     * Guess instance name from the endpoint.
+     */
+    public static function make(string $endpoint): string
+    {
+        $hostname = parse_url($endpoint, PHP_URL_HOST);
+
+        if ($hostname === false || $hostname === null) {
+            throw new InvalidArgumentException(sprintf(
+                'Could not resolve the instance from the endpoint [%s].', $endpoint
+            ));
+        }
+
+        return explode('.', $hostname)[0];
+    }
+}

--- a/src/Tablestore.php
+++ b/src/Tablestore.php
@@ -20,15 +20,20 @@ class Tablestore
     protected BuildsSignature $signature;
 
     /**
+     * The instance name.
+     */
+    protected string $instance;
+
+    /**
      * Create a Tablestore.
      */
     public function __construct(
         protected string $accessKeyId,
         protected string $accessKeySecret,
         protected string $endpoint,
-        protected string $instance
+        string $instance = null
     ) {
-        //
+        $this->instance = $instance ?? GuessInstanceName::make($endpoint);
     }
 
     /**

--- a/tests/GuessInstanceNameTest.php
+++ b/tests/GuessInstanceNameTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Dew\Tablestore\GuessInstanceName;
+
+test('instance resolution public endpoint', function () {
+    expect(GuessInstanceName::make('https://instance.cn-hangzhou.ots.aliyuncs.com'))
+        ->toBe('instance');
+});
+
+test('instance resolution vpc endpoint', function () {
+    expect(GuessInstanceName::make('https://instance.cn-hangzhou.vpc.tablestore.aliyuncs.com'))
+        ->toBe('instance');
+});
+
+test('resolution with invalid endpoint', function () {
+    expect(fn () => GuessInstanceName::make(''))
+        ->toThrow(InvalidArgumentException::class, 'Could not resolve the instance from the endpoint [].');
+});


### PR DESCRIPTION
When initializing a Tablestore client, if the instance name is not passed in, we would guess it from the endpoint instead.