### PR TITLE
Handles HTTP client and server exceptions

### DIFF
--- a/src/BatchHandler.php
+++ b/src/BatchHandler.php
@@ -4,7 +4,6 @@ namespace Dew\Tablestore;
 
 use Dew\Tablestore\Concerns\InteractsWithRequest;
 use Dew\Tablestore\Exceptions\BatchHandlerException;
-use Google\Protobuf\Internal\Message;
 use Protos\BatchGetRowRequest;
 use Protos\BatchGetRowResponse;
 use Protos\BatchWriteRowRequest;
@@ -228,15 +227,5 @@ class BatchHandler
             ->setRowChange($buffer)
             ->setCondition($this->toCondition($builder))
             ->setReturnContent($this->toReturnContent($builder));
-    }
-
-    /**
-     * Communicate with Tablestore with the given message.
-     */
-    protected function send(string $endpoint, Message $message): string
-    {
-        return $this->tablestore->send($endpoint, $message)
-            ->getBody()
-            ->getContents();
     }
 }

--- a/src/Exceptions/TablestoreException.php
+++ b/src/Exceptions/TablestoreException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Dew\Tablestore\Exceptions;
+
+use Exception;
+use Protos\Error;
+use Psr\Http\Message\ResponseInterface;
+
+class TablestoreException extends Exception
+{
+    /**
+     * Create a Tablestore exception.
+     */
+    public function __construct(
+        protected Error $e
+    ) {
+        parent::__construct($e->getMessage());
+    }
+
+    /**
+     * Create a Tablestore exception from error response.
+     */
+    public static function fromResponse(ResponseInterface $response): self
+    {
+        $error = new Error;
+        $error->mergeFromString($response->getBody()->getContents());
+
+        return new self($error);
+    }
+
+    /**
+     * Get the error message.
+     */
+    public function getError(): Error
+    {
+        return $this->e;
+    }
+}

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -4,7 +4,6 @@ namespace Dew\Tablestore;
 
 use Dew\Tablestore\Concerns\InteractsWithRequest;
 use Dew\Tablestore\Responses\RowDecodableResponse;
-use Google\Protobuf\Internal\Message;
 use Protos\DeleteRowRequest;
 use Protos\DeleteRowResponse;
 use Protos\GetRowRequest;
@@ -120,23 +119,5 @@ class Handler
         $response->mergeFromString($this->send('/GetRow', $request));
 
         return new RowDecodableResponse($response);
-    }
-
-    /**
-     * Communicate with Tablestore with the given message.
-     */
-    protected function send(string $endpoint, Message $message): string
-    {
-        return $this->tablestore->send($endpoint, $message)
-            ->getBody()
-            ->getContents();
-    }
-
-    /**
-     * The tablestore client.
-     */
-    public function tablestore(): Tablestore
-    {
-        return $this->tablestore;
     }
 }


### PR DESCRIPTION
Display the detailed error message from the remote server when something wrong happens without the need to decode the Protobuf error message from scratch.

It's useful when a query fails the condition checking where the message would be a straight "Condition check failed." instead of a foggy general HTTP error message like "_[The request]_ resulted in a \`400 Bad Request\` response".